### PR TITLE
feat(compare): warn on zero-hit terms and suggest correct domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to **backendpro** are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] — Unreleased
+
+### Added
+- **Smarter `compare`** — when a queried term has zero hits in the chosen domain, the result no longer silently fills the column with `—`. Instead the entry is blanked, the name is added to a new `missing` list, and `suggestions` point at other domains where the term actually lives (e.g. `compare cosmosdb dynamodb` now hints `try --domain cloud → Cosmos DB`). Markdown output renders a `> ⚠️` warning block above the table.
+- **Product-name synonyms** — query expansion now bridges no-space variants (`cosmosdb` ↔ `cosmos db`, `dynamodb` ↔ `dynamo db`, `mongodb`, `clickhouse`, `bigquery`, `elasticsearch`, `rabbitmq`, `kubernetes`/`k8s`, `postgres`/`postgresql`, etc.).
+
+### Fixed
+- `compare` no longer surfaces a tangentially related row (e.g. MongoDB for `cosmosdb`) just because BM25 scored it highest — matches now require the identifier column to actually contain the queried name (space-insensitive).
+
 ## [0.2.0] — 2026-04-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "backendpro"
-version = "0.2.0"
+version = "0.2.1"
 description = "Backend Pro Max — BM25-searchable backend & distributed-systems engineering intelligence as an AI skill / CLI."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/backend-pro-max/scripts/core.py
+++ b/src/backend-pro-max/scripts/core.py
@@ -322,6 +322,29 @@ _SYNONYMS = {
     "graphql":     ["api", "schema"],
     "rest":        ["api", "http"],
     "grpc":        ["rpc", "protobuf"],
+    # Product-name aliases — users often drop spaces ("cosmosdb" vs "Cosmos DB").
+    # We expand the no-space form to the multi-token form so BM25 can match.
+    "cosmosdb":    ["cosmos", "db"],
+    "dynamodb":    ["dynamo", "db"],
+    "documentdb": ["document", "db"],
+    "mongodb":     ["mongo", "db"],
+    "couchdb":     ["couch", "db"],
+    "cockroachdb": ["cockroach", "db"],
+    "scylladb":    ["scylla", "db"],
+    "influxdb":    ["influx", "db"],
+    "rocksdb":     ["rocks", "db"],
+    "timescaledb": ["timescale", "db"],
+    "clickhouse":  ["click", "house", "olap"],
+    "bigquery":    ["big", "query"],
+    "bigtable":    ["big", "table"],
+    "elasticsearch": ["elastic", "search"],
+    "opensearch":  ["open", "search"],
+    "rabbitmq":    ["rabbit", "mq", "amqp"],
+    "activemq":    ["active", "mq"],
+    "kubernetes":  ["k8s"],
+    "k8s":         ["kubernetes"],
+    "postgresql":  ["postgres"],
+    "postgres":    ["postgresql"],
 }
 
 
@@ -630,6 +653,8 @@ def compare(names, domain=None, max_per_name=1):
 
     entries = {}
     columns_seen = []
+    missing = []
+    suggestions = {}
     for name in names:
         result = search(name, domain=auto_domain, max_results=max(5, max_per_name * 5))
         rows = result.get("results", [])
@@ -641,7 +666,37 @@ def compare(names, domain=None, max_per_name=1):
             0 if name_l in str(next(iter(r.values()), "")).lower() else 1,
             -float(r.get("_score", 0.0)),
         ))
-        entry = rows[0] if rows else {}
+        top = rows[0] if rows else None
+        # Treat as a real hit only when the identifier column actually
+        # contains the queried name. Otherwise BM25 may surface a tangentially
+        # related row (e.g. searching "cosmosdb" in `database` returns MongoDB
+        # because of the "document" overlap) — that's misleading in a compare
+        # table, so we mark it as missing and look elsewhere.
+        found = bool(top) and name_l in str(next(iter(top.values()), "")).lower()
+        # Normalised match: also accept hits where the user dropped spaces
+        # ("cosmosdb" should match "Cosmos DB").
+        if not found and top:
+            head_l = str(next(iter(top.values()), "")).lower()
+            if re.sub(r"\s+", "", name_l) in re.sub(r"\s+", "", head_l):
+                found = True
+        if found:
+            entry = top
+        else:
+            entry = {}
+            missing.append(name)
+            # Cross-domain fallback: where else does this term actually live?
+            cross = search_all(name, max_results=1)
+            hints = []
+            name_compact = re.sub(r"\s+", "", name_l)
+            for d, hits in cross.get("results", {}).items():
+                if d == auto_domain or not hits:
+                    continue
+                head = str(next(iter(hits[0].values()), "")).strip()
+                head_compact = re.sub(r"\s+", "", head.lower())
+                if name_compact in head_compact:
+                    hints.append({"domain": d, "match": head})
+            if hints:
+                suggestions[name] = hints[:3]
         entries[name] = entry
         for col in entry.keys():
             if col not in columns_seen and col != "_score":
@@ -653,6 +708,8 @@ def compare(names, domain=None, max_per_name=1):
         "names": list(names),
         "columns": columns_seen,
         "entries": entries,
+        "missing": missing,
+        "suggestions": suggestions,
     }
 
 

--- a/src/backend-pro-max/scripts/search.py
+++ b/src/backend-pro-max/scripts/search.py
@@ -131,6 +131,23 @@ def format_compare(result):
         return f"Error: {result['error']}"
     out = [f"## Backend Pro Max — Compare ({result['domain']})",
            f"**Comparing:** {' vs '.join(result['names'])}\n"]
+
+    # Surface zero-hit terms before the table so the user doesn't read a row
+    # full of `—` and assume the tool is broken.
+    missing = result.get("missing") or []
+    suggestions = result.get("suggestions") or {}
+    if missing:
+        out.append(f"> ⚠️  No matches in `{result['domain']}` for: "
+                   + ", ".join(f"**{m}**" for m in missing))
+        for name in missing:
+            hints = suggestions.get(name) or []
+            if hints:
+                pretty = "; ".join(f"`--domain {h['domain']}` → {h['match']}" for h in hints)
+                out.append(f"> &nbsp;&nbsp;↳ try for **{name}**: {pretty}")
+            else:
+                out.append(f"> &nbsp;&nbsp;↳ **{name}** not found in any domain — check spelling or add it to a CSV.")
+        out.append("")
+
     cols = result["columns"]
     if not cols:
         out.append("_No entries found for any of the names._")

--- a/tests/test_cache_and_compare.py
+++ b/tests/test_cache_and_compare.py
@@ -45,6 +45,21 @@ def test_compare_requires_two_names():
     assert "error" in res
 
 
+def test_compare_warns_on_zero_hit_term_and_suggests_domain():
+    """cosmosdb only lives in cloud.csv; comparing it against dynamodb in
+    the auto-detected `database` domain should flag it as missing and
+    point the user at the cloud domain."""
+    core.clear_cache()
+    res = core.compare(["cosmosdb", "dynamodb"])
+    assert "cosmosdb" in res["missing"]
+    assert "dynamodb" not in res["missing"]
+    hints = res["suggestions"].get("cosmosdb", [])
+    assert any(h["domain"] == "cloud" for h in hints), hints
+    # The blanked-out missing entry must not pollute the table with a
+    # misleading neighbour row.
+    assert res["entries"]["cosmosdb"] == {}
+
+
 def test_find_stale_skips_undated_rows(tmp_path: Path, monkeypatch):
     csv_path = tmp_path / "x.csv"
     with open(csv_path, "w", newline="", encoding="utf-8") as f:


### PR DESCRIPTION
## Why

Running \`backendpro compare cosmosdb dynamodb\` silently produced a column full of \`—\` for cosmosdb because:
1. Cosmos DB lives in \`cloud.csv\`, not \`databases.csv\`.
2. The auto-detected domain was \`database\`, and BM25 returned MongoDB as the top hit for \`cosmosdb\` (loose token overlap on \"document\").
3. The previous \`compare()\` accepted that row, then \`format_compare()\` rendered \`—\` for every missing field with no explanation.

Net effect: the tool looked broken on a totally reasonable query.

## What

**\`compare()\` is now strict + helpful:**
- A row only counts as a hit when its identifier column actually contains the queried name (space-insensitive — \`cosmosdb\` matches \`Cosmos DB\`).
- New \`missing\` list + \`suggestions\` dict in the return value. For each unmatched name we run \`search_all\` and surface other domains where the term lives.
- \`format_compare()\` renders a \`> ⚠️\` warning block above the table, e.g.:
  > ⚠️  No matches in \`database\` for: **cosmosdb**
  > &nbsp;&nbsp;↳ try for **cosmosdb**: \`--domain cloud\` → Cosmos DB

**Product-name synonyms** added so no-space variants work everywhere (cosmosdb, dynamodb, mongodb, clickhouse, bigquery, elasticsearch, rabbitmq, k8s/kubernetes, postgres/postgresql, …).

## Tests

- New regression test: \`test_compare_warns_on_zero_hit_term_and_suggests_domain\`.
- Full suite: **38 passed**, ruff clean.

## Version

Bumps to **0.2.1**, CHANGELOG updated.